### PR TITLE
Covers LU-7599 and LU-7600

### DIFF
--- a/BlaiseDataDelivery.Tests/MessageHandler/DataDeliveryMessageHandlerTests.cs
+++ b/BlaiseDataDelivery.Tests/MessageHandler/DataDeliveryMessageHandlerTests.cs
@@ -46,7 +46,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             _mapperMock.Setup(m => m.MapToMessageModel(_message)).Returns(_messageModel);
 
             _fileServiceMock = new Mock<IFileService>();
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(),It.IsAny<string>())).Returns(new List<string>());
             _fileServiceMock.Setup(f => f.CreateEncryptedZipFile(It.IsAny<IList<string>>(), It.IsAny<MessageModel>()));
             _fileServiceMock.Setup(f => f.UploadFileToBucket(It.IsAny<string>(), It.IsAny<string>()));
             _fileServiceMock.Setup(f => f.DeleteFile(It.IsAny<string>()));
@@ -85,7 +85,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             _configurationMock.Setup(c => c.FilePattern).Returns(filePattern);
             _configurationMock.Setup(c => c.BucketName).Returns(bucketName);
 
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(filesToProcess);
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(),It.IsAny<string>())).Returns(filesToProcess);
             _fileServiceMock.Setup(f => f.CreateEncryptedZipFile(It.IsAny<IList<string>>(), It.IsAny<MessageModel>())).Returns(encryptedZipFilePath);
 
             //act
@@ -94,7 +94,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             //assert
             _mapperMock.Verify(v => v.MapToMessageModel(_message), Times.Once);
 
-            _fileServiceMock.Verify(v => v.GetFiles(_messageModel.SourceFilePath, filePattern));
+            _fileServiceMock.Verify(v => v.GetFiles(_messageModel.SourceFilePath, _messageModel.InstrumentName,filePattern));
             _fileServiceMock.Verify(v => v.CreateEncryptedZipFile(filesToProcess, _messageModel), Times.Once);
             _fileServiceMock.Verify(v => v.UploadFileToBucket(encryptedZipFilePath, bucketName), Times.Once);
             _fileServiceMock.Verify(v => v.DeleteFile(encryptedZipFilePath), Times.Once);
@@ -120,7 +120,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             _configurationMock.Setup(c => c.FilePattern).Returns(filePattern);
             _configurationMock.Setup(c => c.BucketName).Returns(bucketName);
 
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(filesToProcess);
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(filesToProcess);
             _fileServiceMock.Setup(f => f.CreateEncryptedZipFile(It.IsAny<IList<string>>(), It.IsAny<MessageModel>())).Returns(encryptedZipFilePath);
 
             //act
@@ -134,7 +134,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
         public void Given_No_Files_Available_To_Process_When_HandleMessage_Is_Called_Then_True_Is_Returned()
         {
             //arrange
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
 
             //act
             var result = _sut.HandleMessage(_message);
@@ -151,7 +151,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             var filePattern = "*.*";
 
             _configurationMock.Setup(c => c.FilePattern).Returns(filePattern);
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<string>());
 
             //act
             _sut.HandleMessage(_message);
@@ -159,7 +159,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
             //assert
             _mapperMock.Verify(v => v.MapToMessageModel(_message), Times.Once);
 
-            _fileServiceMock.Verify(v => v.GetFiles(_messageModel.SourceFilePath, filePattern));
+            _fileServiceMock.Verify(v => v.GetFiles(_messageModel.SourceFilePath, _messageModel.InstrumentName, filePattern));
             _fileServiceMock.Verify(v => v.CreateEncryptedZipFile(It.IsAny<IList<string>>(), It.IsAny<MessageModel>()), Times.Never);
             _fileServiceMock.Verify(v => v.UploadFileToBucket(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _fileServiceMock.Verify(v => v.DeleteFile(It.IsAny<string>()), Times.Never);
@@ -170,7 +170,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
         public void Given_An_Exception_Occurs_During_Processing_When_HandleMessage_Is_Called_Then_False_Is_Returned()
         {
             //arrange
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
 
             //act
             var result = _sut.HandleMessage(_message);
@@ -184,7 +184,7 @@ namespace BlaiseDataDelivery.Tests.MessageHandler
         public void Given_An_Exception_Occurs_During_Processing_When_HandleMessage_Is_Called_Then_The_Exception_Is_Not_Bubbled_Up()
         {
             //arrange
-            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+            _fileServiceMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
 
             //act && assert
             Assert.DoesNotThrow(() => _sut.HandleMessage(_message));

--- a/BlaiseDataDelivery.Tests/Providers/ConfigurationProviderTests.cs
+++ b/BlaiseDataDelivery.Tests/Providers/ConfigurationProviderTests.cs
@@ -60,5 +60,44 @@ namespace BlaiseDataDelivery.Tests.Providers
             //assert
             Assert.AreEqual("DeadletterTopicIdTest", result);
         }
+
+        [Test]
+        public void Given_I_Call_FilePattern_I_Get_The_Correct_Value_Back()
+        {
+            //arrange
+            var configurationProvider = new ConfigurationProvider();
+
+            //act
+            var result = configurationProvider.FilePattern;
+
+            //assert
+            Assert.AreEqual("FilePatternTest", result);
+        }
+
+        [Test]
+        public void Given_I_Call_BucketName_I_Get_The_Correct_Value_Back()
+        {
+            //arrange
+            var configurationProvider = new ConfigurationProvider();
+
+            //act
+            var result = configurationProvider.BucketName;
+
+            //assert
+            Assert.AreEqual("BucketNameTest", result);
+        }
+
+        [Test]
+        public void Given_I_Call_EncryptionKey_I_Get_The_Correct_Value_Back()
+        {
+            //arrange
+            var configurationProvider = new ConfigurationProvider();
+
+            //act
+            var result = configurationProvider.EncryptionKey;
+
+            //assert
+            Assert.AreEqual("EncryptionKeyTest", result);
+        }
     }
 }

--- a/BlaiseDataDelivery.Tests/Services/Files/FileServiceTests.cs
+++ b/BlaiseDataDelivery.Tests/Services/Files/FileServiceTests.cs
@@ -36,13 +36,14 @@ namespace BlaiseDataDelivery.Tests.Services.Files
         {
             //arrange
             var path = "temp";
+            var instrumentName = "OPN2004";
             var filePattern = "*.*";
 
             //act
-            _sut.GetFiles(path, filePattern);
+            _sut.GetFiles(path, instrumentName, filePattern);
 
             //assert
-            _fileDirectoryMock.Verify(v => v.GetFiles(path, filePattern), Times.Once);
+            _fileDirectoryMock.Verify(v => v.GetFiles(path, $"{instrumentName}{filePattern}"), Times.Once);
         }
 
         [Test]
@@ -50,6 +51,7 @@ namespace BlaiseDataDelivery.Tests.Services.Files
         {
             //arrange
             var path = "temp";
+            var instrumentName = "OPN2004";
             var filePattern = "*.*";
             var files = new List<string> { "File1", "File2" };
 
@@ -57,7 +59,7 @@ namespace BlaiseDataDelivery.Tests.Services.Files
             _fileDirectoryMock.Setup(f => f.GetFiles(It.IsAny<string>(), It.IsAny<string>())).Returns(files);
 
             //act
-            var result = _sut.GetFiles(path, filePattern);
+            var result = _sut.GetFiles(path, instrumentName, filePattern);
 
             //assert
             Assert.NotNull(result);

--- a/BlaiseDataDelivery.Tests/app.config
+++ b/BlaiseDataDelivery.Tests/app.config
@@ -6,6 +6,9 @@
     <add key="DeadletterTopicId" value="DeadletterTopicIdTest" />
     <add key="SubscriptionTopicId" value="SubscriptionTopicIdTest" />
     <add key="SubscriptionId" value="SubscriptionIdTest" />
+    <add key="FilePattern" value="FilePatternTest" />
+    <add key="BucketName" value="BucketNameTest" />
+    <add key="EncryptionKey" value="EncryptionKeyTest" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/BlaiseDataDelivery/Interfaces/Services/Files/IFileService.cs
+++ b/BlaiseDataDelivery/Interfaces/Services/Files/IFileService.cs
@@ -7,7 +7,7 @@ namespace BlaiseDataDelivery.Interfaces.Services.Files
     {
         string CreateEncryptedZipFile(IList<string> files, MessageModel messageModel);
 
-        IEnumerable<string> GetFiles(string path, string filePattern);
+        IEnumerable<string> GetFiles(string path, string messageModelInstrumentName, string filePattern);
 
         void UploadFileToBucket(string zipFilePath, string bucketName);
         void DeleteFiles(IEnumerable<string> files);

--- a/BlaiseDataDelivery/MessageHandlers/DataDeliveryMessageHandler.cs
+++ b/BlaiseDataDelivery/MessageHandlers/DataDeliveryMessageHandler.cs
@@ -56,7 +56,7 @@ namespace BlaiseDataDelivery.MessageHandlers
 
                 //clean up files
                 _fileService.DeleteFile(encryptedZipFile);
-               _fileService.DeleteFiles(filesToProcess);
+
                _logger.Info($"Cleaned up the source and temporary files");
 
                 return true;

--- a/BlaiseDataDelivery/MessageHandlers/DataDeliveryMessageHandler.cs
+++ b/BlaiseDataDelivery/MessageHandlers/DataDeliveryMessageHandler.cs
@@ -35,7 +35,7 @@ namespace BlaiseDataDelivery.MessageHandlers
                 var messageModel = _mapper.MapToMessageModel(message);
 
                 //get a list of available files for data delivery
-                var filesToProcess = _fileService.GetFiles(messageModel.SourceFilePath, _configuration.FilePattern).ToList();
+                var filesToProcess = _fileService.GetFiles(messageModel.SourceFilePath, messageModel.InstrumentName, _configuration.FilePattern).ToList();
 
                 //no files available - an error must have occured
                 if(!filesToProcess.Any())

--- a/BlaiseDataDelivery/Services/Files/FileService.cs
+++ b/BlaiseDataDelivery/Services/Files/FileService.cs
@@ -52,9 +52,9 @@ namespace BlaiseDataDelivery.Services.Files
             }
         }
 
-        public IEnumerable<string> GetFiles(string path, string filePattern)
+        public IEnumerable<string> GetFiles(string path, string instrumentName, string filePattern)
         {
-            return _directoryService.GetFiles(path, filePattern);
+            return _directoryService.GetFiles(path, $"{instrumentName}{filePattern}");
         }
 
         public void UploadFileToBucket(string zipFilePath, string bucketName)


### PR DESCRIPTION
LU-7599
Issue was that the DD process was not filtering files at the source location based on instrument name. Created a test to replicate and fixed to code to pass the test

LU-7600
We need to keep the source files after processing. Added a test to replicate the bug LU-7600, and fixed the code.

