### PR TITLE
Blais5 33

### DIFF
--- a/scripts/Opn/DeliverOpnInstruments.ps1
+++ b/scripts/Opn/DeliverOpnInstruments.ps1
@@ -27,8 +27,6 @@ try {
     $serverParkName = $env:ServerParkName
     LogInfo("Server park name: $ServerParkName")
 
-    BLAISE_SERVERPARK
-
     # Retrieve a list of active instruments in CATI for a particular survey type I.E OPN
     $instruments = GetListOfInstrumentsBySurveyType -restApiBaseUrl $restAPIUrl -surveyType $surveyType
 

--- a/scripts/Opn/DeliverOpnInstruments.ps1
+++ b/scripts/Opn/DeliverOpnInstruments.ps1
@@ -24,6 +24,10 @@ try {
     LogInfo("Survey type: $surveyType")
     $packageExtension = $env:PackageExtension
     LogInfo("Package Extension: $packageExtension")
+    $serverParkName = $env:ServerParkName
+    LogInfo("Server park name: $ServerParkName")
+
+    BLAISE_SERVERPARK
 
     # Retrieve a list of active instruments in CATI for a particular survey type I.E OPN
     $instruments = GetListOfInstrumentsBySurveyType -restApiBaseUrl $restAPIUrl -surveyType $surveyType
@@ -72,7 +76,10 @@ try {
             $deliveryFile = "$using:tempPath\$deliveryFileName"
 
             # Download instrument package
-            DownloadInstrumentPackage -restApiBaseUrl $using:restAPIUrl -serverParkName $_.serverParkName -instrumentName $_.name -fileName $deliveryFile
+            DownloadFileFromBucket -instrumentFileName "$($_.name).bpkg" -bucketName $using:dqsBucket -filePath $deliveryFile
+
+            # Populate data
+            C:\BlaiseServices\BlaiseCli\blaise.cli datadelivery -s $using:serverParkName -i $_.name -f $deliveryFile
 
             # Create a temporary folder for processing instruments
             $processingFolder = CreateANewFolder -folderPath $using:tempPath -folderName "$($_.name)_$(Get-Date -format "ddMMyyyy")_$(Get-Date -format "HHmmss")"

--- a/scripts/functions/CloudFunctions.ps1
+++ b/scripts/functions/CloudFunctions.ps1
@@ -20,12 +20,45 @@ function UploadFileToBucket {
     }
 
     LogInfo("Copying '$filePath' to '$bucketName'")
+
     # GSUtils logs its progress bar to stderr, standard powershell core throws an error
     # when run from azure because of this, using cmd seemed to be the only option but
     # it swallows errors so we then have to check the output for exceptions
     $output = & cmd /c "gsutil 2>&1" cp $filePath gs://$bucketName/$deliveryFileName
+
     if ($output -Like "*exception*") {
         throw "Failed to upload '$filePath' to '$bucketName': '$output'"
     }
+    
     LogInfo("Copied '$filePath' to '$bucketName'")
+}
+
+function DownloadFileFromBucket {
+    param (
+    [string] $instrumentFileName,
+    [string] $bucketName,
+    [string] $filePath
+    )
+
+    If ([string]::IsNullOrEmpty($instrumentFileName)) {
+        throw "No instrument file name has been provided"
+    }
+
+    If ([string]::IsNullOrEmpty($bucketName)) {
+        throw "No bucket name provided"
+    }
+
+    If (-not (Test-Path $filePath)) {
+        throw "$filePath not found"
+    }
+
+    LogInfo("Downloading '$instrumentFileName' from '$bucketName' to '$bucketName'")
+
+    $output = & cmd /c "gsutil 2>&1" cp gs://$bucketName/$instrumentFileName $filePath
+
+    if ($output -Like "*exception*") {
+        throw "Failed to download '$instrumentFileName' from '$bucketName': '$output'"
+    }
+
+    LogInfo("Downloaded '$instrumentFileName' from '$bucketName' to '$bucketName'")
 }

--- a/scripts/functions/CloudFunctions.ps1
+++ b/scripts/functions/CloudFunctions.ps1
@@ -48,8 +48,8 @@ function DownloadFileFromBucket {
         throw "No bucket name provided"
     }
 
-    If (-not (Test-Path $filePath)) {
-        throw "$filePath not found"
+    If ([string]::IsNullOrEmpty($filePath)) {
+        throw "No file path provided"
     }
 
     LogInfo("Downloading '$instrumentFileName' from '$bucketName' to '$bucketName'")

--- a/scripts/functions/RestApiFunctions.ps1
+++ b/scripts/functions/RestApiFunctions.ps1
@@ -25,31 +25,3 @@ function GetListOfInstrumentsBySurveyType {
 
     return $allInstruments | Where-Object { $_.name.StartsWith($surveyType) }
 }
-
-function DownloadInstrumentPackage {
-    param (
-        [string] $restApiBaseUrl,
-        [string] $serverParkName,
-        [string] $instrumentName,
-        [string] $fileName
-    )
-
-    If ([string]::IsNullOrEmpty($serverParkName)) {
-        throw "No server park name provided"
-    }
-
-    If ([string]::IsNullOrEmpty($instrumentName)) {
-        throw "No instrument name provided"
-    }
-
-    If ([string]::IsNullOrEmpty($fileName)) {
-        throw "No file name provided"
-    }
-
-    # Build uri to retrive instrument package file with data
-    $InstrumentDataUri = "$restApiBaseUrl/api/v1/serverparks/$serverParkName/instruments/$instrumentName/data"
-
-    # Download instrument package
-    Invoke-WebRequest $InstrumentDataUri -outfile $fileName
-    LogInfo("Downloaded instrument '$fileName'")
-}

--- a/scripts/lms/DeliverLmsInstruments.ps1
+++ b/scripts/lms/DeliverLmsInstruments.ps1
@@ -48,7 +48,7 @@ try {
         $process = GetProcess -instrument $_ -sync $using:sync
 
         try {
-            . "$using:dqsBucketPSScriptRoot\..\functions\LoggingFunctions.ps1"
+            . "$using:PSScriptRoot\..\functions\LoggingFunctions.ps1"
             . "$using:PSScriptRoot\..\functions\FileFunctions.ps1"
             . "$using:PSScriptRoot\..\functions\DataDeliveryStatusFunctions.ps1"
             . "$using:PSScriptRoot\..\functions\RestApiFunctions.ps1"


### PR DESCRIPTION
Updated OPN and LMS pipelines to no longer is the REST api to populate instrument data. It now downloads the package direct from the bucket and uses the blaise-cli service to popuate data